### PR TITLE
feat: 로그인한 유저 정보 조회 API 추가

### DIFF
--- a/back-end/src/main/java/kr/co/ssalon/web/controller/UserController.java
+++ b/back-end/src/main/java/kr/co/ssalon/web/controller/UserController.java
@@ -12,12 +12,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.coyote.BadRequestException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 
-@Tag(name = "회원가입 API")
+@Tag(name = "회원 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -35,5 +36,17 @@ public class UserController {
         Member currentUser = memberService.signup(username, additionalInfo);
 
         return new MemberDTO(currentUser);
+    }
+
+    @Operation(summary = "회원 정보 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+    })
+    @GetMapping("/users/me/profile")
+    public MemberDTO getUserInfo(@AuthenticationPrincipal CustomOAuth2Member customOAuth2Member) throws BadRequestException {
+        String username = customOAuth2Member.getUsername();
+        Member member = memberService.findMember(username);
+        log.info("user = {}", member);
+        return new MemberDTO(member);
     }
 }


### PR DESCRIPTION
GET /users/me/profile API
소셜 로그인 시 온보딩 페이지 표시 여부를 체크하기 위해 먼저 작업하였습니다.
=> 해당 API로 유저 정보 조회 후, 온보딩에서 작성되었어야 할 필드가 비어 있는 경우 온보딩 페이지 표시

기존에 존재하던 TestSignUpController을 바탕으로 작성하였습니다.