### PR TITLE
feat: 로그아웃 API 추가

### DIFF
--- a/back-end/src/main/java/kr/co/ssalon/config/SecurityConfig.java
+++ b/back-end/src/main/java/kr/co/ssalon/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import kr.co.ssalon.jwt.JWTFilter;
 import kr.co.ssalon.jwt.JWTUtil;
 import kr.co.ssalon.jwt.RedisRefreshTokenRepository;
+import kr.co.ssalon.oauth2.handler.CustomLogoutFilter;
 import kr.co.ssalon.oauth2.handler.CustomSuccessHandler;
 import kr.co.ssalon.oauth2.oauthService.CustomOAuth2MemberService;
 import lombok.RequiredArgsConstructor;
@@ -81,7 +82,7 @@ public class SecurityConfig {
 
 
         // 로그아웃 필터 추가
-        // http.addFilterBefore(new CustomLogoutFilter(jwtUtil, redisRefreshTokenRepository), LogoutFilter.class);
+         http.addFilterBefore(new CustomLogoutFilter(jwtUtil, redisRefreshTokenRepository), LogoutFilter.class);
 
 
         // oauth2

--- a/back-end/src/main/java/kr/co/ssalon/oauth2/handler/CustomLogoutFilter.java
+++ b/back-end/src/main/java/kr/co/ssalon/oauth2/handler/CustomLogoutFilter.java
@@ -31,13 +31,13 @@ public class CustomLogoutFilter extends GenericFilterBean {
     private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
         log.info("logoutFilter");
         String requestURI = request.getRequestURI();
-        if (!requestURI.matches("^\\/logout$")) {
+        if (!requestURI.matches("^\\/auth\\/logout$")) {
             chain.doFilter(request, response);
             return;
         }
         String requestMethod = request.getMethod();
 
-        if (!requestMethod.equals("POST")) {
+        if (!requestMethod.equals("DELETE")) {
             chain.doFilter(request, response);
             return;
         }
@@ -45,9 +45,11 @@ public class CustomLogoutFilter extends GenericFilterBean {
         String refresh = null;
 
         Cookie[] cookies = request.getCookies();
-        for (Cookie cookie : cookies) {
-            if (cookie.getName().equals("refresh")) {
-                refresh = cookie.getValue();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals("refresh")) {
+                    refresh = cookie.getValue();
+                }
             }
         }
 
@@ -81,10 +83,6 @@ public class CustomLogoutFilter extends GenericFilterBean {
         RedisRefreshToken deleteRefresh = redisRefreshTokenRepository.findByRefresh(refresh);
         redisRefreshTokenRepository.delete(deleteRefresh);
 
-        Cookie logoutRefreshCookie = createLogoutRefreshCookie();
-        Cookie logoutAccessCookie = createLogoutAccessCookie();
-        response.addCookie(logoutAccessCookie);
-        response.addCookie(logoutRefreshCookie);
         response.setStatus(HttpServletResponse.SC_OK);
     }
 

--- a/back-end/src/main/java/kr/co/ssalon/oauth2/handler/CustomLogoutFilter.java
+++ b/back-end/src/main/java/kr/co/ssalon/oauth2/handler/CustomLogoutFilter.java
@@ -1,0 +1,104 @@
+package kr.co.ssalon.oauth2.handler;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.co.ssalon.jwt.JWTUtil;
+import kr.co.ssalon.jwt.RedisRefreshToken;
+import kr.co.ssalon.jwt.RedisRefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Slf4j
+public class CustomLogoutFilter extends GenericFilterBean {
+    private final JWTUtil jwtUtil;
+    private final RedisRefreshTokenRepository redisRefreshTokenRepository;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
+    }
+
+    private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
+        log.info("logoutFilter");
+        String requestURI = request.getRequestURI();
+        if (!requestURI.matches("^\\/logout$")) {
+            chain.doFilter(request, response);
+            return;
+        }
+        String requestMethod = request.getMethod();
+
+        if (!requestMethod.equals("POST")) {
+            chain.doFilter(request, response);
+            return;
+        }
+        log.info("logoutFilter check");
+        String refresh = null;
+
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals("refresh")) {
+                refresh = cookie.getValue();
+            }
+        }
+
+        if (refresh == null) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        try {
+            jwtUtil.isExpired(refresh);
+
+        } catch (ExpiredJwtException e) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        String category = jwtUtil.getCategory(refresh);
+
+        if (!category.equals("refresh")) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+        Boolean isExist = redisRefreshTokenRepository.existsByRefresh(refresh);
+        if (!isExist) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+
+        //***** 로그아웃 진행 *****
+        RedisRefreshToken deleteRefresh = redisRefreshTokenRepository.findByRefresh(refresh);
+        redisRefreshTokenRepository.delete(deleteRefresh);
+
+        Cookie logoutRefreshCookie = createLogoutRefreshCookie();
+        Cookie logoutAccessCookie = createLogoutAccessCookie();
+        response.addCookie(logoutAccessCookie);
+        response.addCookie(logoutRefreshCookie);
+        response.setStatus(HttpServletResponse.SC_OK);
+    }
+
+    private Cookie createLogoutRefreshCookie() {
+        Cookie cookie = new Cookie("refresh", null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        return cookie;
+    }
+
+    private Cookie createLogoutAccessCookie() {
+        Cookie cookie = new Cookie("Authorization", null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        return cookie;
+    }
+}

--- a/back-end/src/main/java/kr/co/ssalon/web/controller/UserController.java
+++ b/back-end/src/main/java/kr/co/ssalon/web/controller/UserController.java
@@ -12,10 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.coyote.BadRequestException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 @Tag(name = "회원 API")
@@ -48,5 +45,14 @@ public class UserController {
         Member member = memberService.findMember(username);
         log.info("user = {}", member);
         return new MemberDTO(member);
+    }
+
+    @Operation(summary = "로그아웃")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+    })
+    @DeleteMapping("/auth/logout")
+    public void logout() {
+        // swagger logout API 작성용으로 만든 빈 메소드
     }
 }


### PR DESCRIPTION
`DELETE /auth/logout`

클라이언트에서 로그아웃 시, 로그아웃 필터(CustomLogoutFilter)에서 Redis의 Refresh Token 제거