### PR TITLE
feat: 모임 리스트 조회 API 추가

### DIFF
--- a/back-end/src/main/java/kr/co/ssalon/domain/entity/Region.java
+++ b/back-end/src/main/java/kr/co/ssalon/domain/entity/Region.java
@@ -1,0 +1,19 @@
+package kr.co.ssalon.domain.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum Region {
+
+    SEOUL("서울특별시"),
+    GYEONGGIDO("경기도"),
+    GANGWONDO("강원도"),
+    GYEONGSANGNAMDO("경상남도"),
+    GYEONGSANGBUKDO("경상북도");
+
+    private final String localName;
+
+    Region(String localName) {
+        this.localName = localName;
+    }
+}

--- a/back-end/src/main/java/kr/co/ssalon/domain/entity/Region.java
+++ b/back-end/src/main/java/kr/co/ssalon/domain/entity/Region.java
@@ -9,7 +9,11 @@ public enum Region {
     GYEONGGIDO("경기도"),
     GANGWONDO("강원도"),
     GYEONGSANGNAMDO("경상남도"),
-    GYEONGSANGBUKDO("경상북도");
+    GYEONGSANGBUKDO("경상북도"),
+    JEOLLABUKDO("전라북도"),
+    JEOLLANAMDO("전라남도"),
+    CHUNGCHEONGNAMDO("충청남도"),
+    CHUNGCHEONGBUKDO("충청북도");
 
     private final String localName;
 

--- a/back-end/src/main/java/kr/co/ssalon/domain/repository/MeetingRepository.java
+++ b/back-end/src/main/java/kr/co/ssalon/domain/repository/MeetingRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+public interface MeetingRepository extends JpaRepository<Meeting,Long>, MeetingRepositoryCustom {
 }

--- a/back-end/src/main/java/kr/co/ssalon/domain/repository/MeetingRepositoryCustom.java
+++ b/back-end/src/main/java/kr/co/ssalon/domain/repository/MeetingRepositoryCustom.java
@@ -1,0 +1,19 @@
+package kr.co.ssalon.domain.repository;
+
+import kr.co.ssalon.domain.entity.Meeting;
+import kr.co.ssalon.web.dto.MeetingSearchCondition;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MeetingRepositoryCustom {
+
+    // 모임 목록 조회
+    // 모임 목록 필터 설정
+    Page<Meeting> searchMoims(MeetingSearchCondition meetingSearchCondition, Pageable pageable);
+
+
+
+
+}

--- a/back-end/src/main/java/kr/co/ssalon/domain/repository/MeetingRepositoryCustomImpl.java
+++ b/back-end/src/main/java/kr/co/ssalon/domain/repository/MeetingRepositoryCustomImpl.java
@@ -1,0 +1,68 @@
+package kr.co.ssalon.domain.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import kr.co.ssalon.domain.entity.Meeting;
+import kr.co.ssalon.domain.entity.Region;
+import kr.co.ssalon.web.dto.MeetingSearchCondition;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static kr.co.ssalon.domain.entity.QMeeting.meeting;
+import static org.springframework.util.StringUtils.hasText;
+
+@Component
+public class MeetingRepositoryCustomImpl implements MeetingRepositoryCustom {
+
+    EntityManager em;
+    JPAQueryFactory query;
+
+    @Autowired
+    public MeetingRepositoryCustomImpl(EntityManager em) {
+        this.em = em;
+        this.query = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<Meeting> searchMoims(MeetingSearchCondition meetingSearchCondition, Pageable pageable) {
+
+        List<Meeting> content = query
+                .selectFrom(meeting)
+                .where(
+                        regionEq(meetingSearchCondition.getRegion()),
+                        categoryNameEq(meetingSearchCondition.getCategoryName()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> totalCountQuery = query
+                .select(meeting.count())
+                .from(meeting)
+                .where(
+                        regionEq(meetingSearchCondition.getRegion()),
+                        categoryNameEq(meetingSearchCondition.getCategoryName())
+                );
+        return PageableExecutionUtils.getPage(content, pageable, totalCountQuery::fetchOne);
+
+
+    }
+
+
+    // 지역 필터링
+    private BooleanExpression regionEq(Region region) {
+        return region != null ? meeting.location.contains(region.getLocalName()) : null;
+    }
+
+    // 카테고리 필터링
+    private BooleanExpression categoryNameEq(String categoryName) {
+        return hasText(categoryName) ? meeting.category.name.eq(categoryName) : null;
+    }
+
+}

--- a/back-end/src/main/java/kr/co/ssalon/domain/service/MeetingService.java
+++ b/back-end/src/main/java/kr/co/ssalon/domain/service/MeetingService.java
@@ -9,6 +9,9 @@ import kr.co.ssalon.oauth2.CustomOAuth2Member;
 import kr.co.ssalon.web.dto.MeetingDTO;
 import lombok.RequiredArgsConstructor;
 import org.apache.coyote.BadRequestException;
+import kr.co.ssalon.web.dto.MeetingSearchCondition;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,5 +46,11 @@ public class MeetingService {
 
         // 참가한 모임 정보 반환
         return new MeetingDTO(meeting);
+    }
+
+    // 모임 목록 조회
+    public Page<Meeting> getMoims(MeetingSearchCondition meetingSearchCondition, Pageable pageable) {
+        Page<Meeting> meetings = meetingRepository.searchMoims(meetingSearchCondition, pageable);
+        return meetings;
     }
 }

--- a/back-end/src/main/java/kr/co/ssalon/web/controller/MeetingController.java
+++ b/back-end/src/main/java/kr/co/ssalon/web/controller/MeetingController.java
@@ -20,6 +20,7 @@ import kr.co.ssalon.web.dto.MeetingSearchCondition;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "모임")
@@ -52,7 +53,7 @@ public class MeetingController {
             @ApiResponse(responseCode = "200",description = "모임 목록 조회 성공"),
     })
     @GetMapping("/moims")
-    public ResponseEntity<Page<MeetingDTO>> getMoims(MeetingSearchCondition meetingSearchCondition, Pageable pageable) {
+    public ResponseEntity<Page<MeetingDTO>> getMoims(@RequestParam MeetingSearchCondition meetingSearchCondition, Pageable pageable) {
         Page<Meeting> moims = meetingService.getMoims(meetingSearchCondition, pageable);
         Page<MeetingDTO> moimsDto = moims.map(meeting -> new MeetingDTO(meeting));
         return ResponseEntity.ok().body(moimsDto);

--- a/back-end/src/main/java/kr/co/ssalon/web/controller/MeetingController.java
+++ b/back-end/src/main/java/kr/co/ssalon/web/controller/MeetingController.java
@@ -23,6 +23,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @Tag(name = "모임")
 @Slf4j
 @RestController
@@ -53,9 +55,9 @@ public class MeetingController {
             @ApiResponse(responseCode = "200",description = "모임 목록 조회 성공"),
     })
     @GetMapping("/moims")
-    public ResponseEntity<Page<MeetingDTO>> getMoims(@RequestParam MeetingSearchCondition meetingSearchCondition, Pageable pageable) {
+    public ResponseEntity<List<MeetingDTO>> getMoims(@RequestParam MeetingSearchCondition meetingSearchCondition, Pageable pageable) {
         Page<Meeting> moims = meetingService.getMoims(meetingSearchCondition, pageable);
         Page<MeetingDTO> moimsDto = moims.map(meeting -> new MeetingDTO(meeting));
-        return ResponseEntity.ok().body(moimsDto);
+        return ResponseEntity.ok().body(moimsDto.getContent());
     }
 }

--- a/back-end/src/main/java/kr/co/ssalon/web/controller/MeetingController.java
+++ b/back-end/src/main/java/kr/co/ssalon/web/controller/MeetingController.java
@@ -49,7 +49,7 @@ public class MeetingController {
     // 현재 개설된 모임 목록
     @Operation(summary = "모임 목록 조회")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200",description = "조회 성공"),
+            @ApiResponse(responseCode = "200",description = "모임 목록 조회 성공"),
     })
     @GetMapping("/moims")
     public ResponseEntity<Page<MeetingDTO>> getMoims(MeetingSearchCondition meetingSearchCondition, Pageable pageable) {

--- a/back-end/src/main/java/kr/co/ssalon/web/controller/MeetingController.java
+++ b/back-end/src/main/java/kr/co/ssalon/web/controller/MeetingController.java
@@ -15,6 +15,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import kr.co.ssalon.domain.entity.Meeting;
+import kr.co.ssalon.web.dto.MeetingSearchCondition;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "모임")
 @Slf4j
@@ -36,5 +42,19 @@ public class MeetingController {
         } catch (BadRequestException e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
         }
+    }
+
+    // 모임 목록 조회
+    // 모임 목록 필터 설정, 목록에 표시될 모임의 숫자 등
+    // 현재 개설된 모임 목록
+    @Operation(summary = "모임 목록 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",description = "조회 성공"),
+    })
+    @GetMapping("/moims")
+    public ResponseEntity<Page<MeetingDTO>> getMoims(MeetingSearchCondition meetingSearchCondition, Pageable pageable) {
+        Page<Meeting> moims = meetingService.getMoims(meetingSearchCondition, pageable);
+        Page<MeetingDTO> moimsDto = moims.map(meeting -> new MeetingDTO(meeting));
+        return ResponseEntity.ok().body(moimsDto);
     }
 }

--- a/back-end/src/main/java/kr/co/ssalon/web/dto/MeetingSearchCondition.java
+++ b/back-end/src/main/java/kr/co/ssalon/web/dto/MeetingSearchCondition.java
@@ -1,0 +1,20 @@
+package kr.co.ssalon.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.ssalon.domain.entity.Region;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "목록 조회 condition")
+@Builder
+public class MeetingSearchCondition {
+    @Schema(description = "카테고리명",example = "운동, 스터디 등")
+    private String categoryName;
+    @Schema(description = "지역",example = "SEOUL, GYEONGGIDO 등")
+    private Region region;
+}


### PR DESCRIPTION
`GET /moims?categoryName=운동&region=SEOUL&page=0&size=10&sort=description,DESC`

categoryName, region 파라미터는 모임 리스트 필터입니다.
page, size, sort를 파라미터로 같이 전달하면 Pageable 객체로 전달 되어, 특정 페이지의 모임 리스트들만 조회합니다. (성능을 위해)