### PR TITLE
test: 회원가입 테스트 코드 추가

### DIFF
--- a/back-end/src/test/java/kr/co/ssalon/domain/repository/MemberRepositoryTest.java
+++ b/back-end/src/test/java/kr/co/ssalon/domain/repository/MemberRepositoryTest.java
@@ -1,0 +1,59 @@
+package kr.co.ssalon.domain.repository;
+
+import kr.co.ssalon.domain.entity.Member;
+import kr.co.ssalon.domain.entity.Region;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class MemberRepositoryTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+
+    @Test
+    @DisplayName("MemberRepository.save() 테스트")
+    @WithMockUser(username = "test") // 테스트 유저 인증 정보
+    public void 회원DB저장() {
+        // given
+
+        // username이 "test"인 소셜로그인 유저가 이미 저장돼 있다고 가정
+        Member member = Member.createMember("test", "test@test.com", "ROLE_USER");
+        memberRepository.save(member);
+
+        // 현재 소셜 로그인한 유저(@WithMockUser) 조회
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String username = authentication.getName();
+        Member currentUser = null;
+        Optional<Member> optionalMember = memberRepository.findByUsername(username);
+        if (optionalMember.isPresent()) {
+            currentUser = optionalMember.get();
+        }
+
+        // 온보딩 페이지에서 입력된 추가정보
+        currentUser.setNickname("닉네임");
+        List<String> interests = new ArrayList<>(Arrays.asList("독서", "영화감상"));
+        currentUser.setInterests(interests);
+        currentUser.setAddress(Region.GYEONGGIDO.getLocalName());
+
+        // when
+        currentUser = memberRepository.save(currentUser);
+
+        // then
+        assertThat(currentUser.getNickname()).isEqualTo("닉네임");
+        assertThat(currentUser.getInterests()).containsAll(Arrays.asList("독서", "영화감상"));
+        assertThat(currentUser.getAddress()).isEqualTo(Region.GYEONGGIDO.getLocalName());
+    }
+}

--- a/back-end/src/test/java/kr/co/ssalon/domain/service/MemberServiceTest.java
+++ b/back-end/src/test/java/kr/co/ssalon/domain/service/MemberServiceTest.java
@@ -1,0 +1,65 @@
+package kr.co.ssalon.domain.service;
+
+import kr.co.ssalon.domain.entity.Member;
+import kr.co.ssalon.domain.entity.Region;
+import kr.co.ssalon.domain.repository.MemberRepository;
+import kr.co.ssalon.web.dto.MemberDTO;
+import org.apache.coyote.BadRequestException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+public class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberService memberService;
+
+
+    @Test
+    @DisplayName("MemberService.signup() 테스트")
+    @WithMockUser(username = "test")
+    public void 회원가입() throws BadRequestException {
+        // given
+
+        // 현재 소셜 로그인한 유저(@WithMockUser) 객체 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String username = authentication.getName();
+
+        //   MemberRepository.findByUsername() stub
+        Member member = Member.createMember("test", "test@test.com", "ROLE_USER");
+        Optional<Member> optionalMember = Optional.of(member);
+        when(memberRepository.findByUsername(username)).thenReturn(optionalMember);
+
+        // 온보딩 페이지에서 입력된 추가정보
+        MemberDTO additionalInfo = MemberDTO.builder()
+                .nickname("닉네임")
+                .interests(new ArrayList<>(Arrays.asList("독서", "영화감상")))
+                .address(Region.GANGWONDO.getLocalName())
+                .build();
+
+        // when
+        Member joinedMember = memberService.signup(username, additionalInfo);
+
+        // then
+        assertThat(joinedMember.getNickname()).isEqualTo("닉네임");
+        assertThat(joinedMember.getInterests()).isEqualTo(new ArrayList<>(Arrays.asList("독서", "영화감상")));
+        assertThat(joinedMember.getAddress()).isEqualTo(Region.GANGWONDO.getLocalName());
+    }
+}

--- a/back-end/src/test/java/kr/co/ssalon/web/controller/MemberControllerTest.java
+++ b/back-end/src/test/java/kr/co/ssalon/web/controller/MemberControllerTest.java
@@ -1,0 +1,86 @@
+package kr.co.ssalon.web.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.ssalon.domain.entity.Member;
+import kr.co.ssalon.domain.entity.MemberDates;
+import kr.co.ssalon.domain.entity.Region;
+import kr.co.ssalon.domain.service.MemberService;
+import kr.co.ssalon.oauth2.CustomOAuth2Member;
+import kr.co.ssalon.web.controller.annotation.WithCustomMockUser;
+import kr.co.ssalon.web.dto.MemberDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+public class MemberControllerTest {
+
+    @MockBean
+    private MemberService memberService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("회원가입 API(POST /api/auth/signup) 테스트")
+    @WithCustomMockUser()
+    public void 회원가입API() throws Exception {
+        // given
+
+        // 현재 소셜 로그인한 유저(@WithCustomMockUser)의 username 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomOAuth2Member customOAuth2Member = (CustomOAuth2Member) authentication.getPrincipal();
+        String username = customOAuth2Member.getUsername();
+
+        // 온보딩 페이지에서 입력된 추가정보
+        MemberDTO additionalInfo = MemberDTO.builder()
+                .nickname("닉네임")
+                .interests(new ArrayList<>(Arrays.asList("독서", "영화감상")))
+                .address(Region.GANGWONDO.getLocalName())
+                .build();
+
+        // MemberService.signup() stub
+        MemberDates memberDates = new MemberDates();
+        memberDates.prePersist();
+        Member joinedMember = Member.builder()
+                        .nickname("닉네임")
+                        .interests(new ArrayList<>(Arrays.asList("독서", "영화감상")))
+                        .address(Region.GANGWONDO.getLocalName())
+                        .memberDates(memberDates)
+                        .build();
+        Mockito.when(memberService.signup(username, additionalInfo)).thenReturn(joinedMember);
+
+        // when
+        String requestBody = objectMapper.writeValueAsString(additionalInfo);
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.post("/api/auth/signup")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.nickname", is("닉네임")))
+                .andExpect(jsonPath("$.interests", contains("독서","영화감상")))
+                .andExpect(jsonPath("$.address", is(Region.GANGWONDO.getLocalName())));
+    }
+}

--- a/back-end/src/test/java/kr/co/ssalon/web/controller/annotation/WithCustomMockUser.java
+++ b/back-end/src/test/java/kr/co/ssalon/web/controller/annotation/WithCustomMockUser.java
@@ -1,0 +1,14 @@
+package kr.co.ssalon.web.controller.annotation;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithCustomMockUserSecurityContextFactory.class)
+public @interface WithCustomMockUser {
+    String username() default "test";
+    String email() default "test@test.com";
+    String role() default "ROLE_USER";
+}

--- a/back-end/src/test/java/kr/co/ssalon/web/controller/annotation/WithCustomMockUserSecurityContextFactory.java
+++ b/back-end/src/test/java/kr/co/ssalon/web/controller/annotation/WithCustomMockUserSecurityContextFactory.java
@@ -1,0 +1,31 @@
+package kr.co.ssalon.web.controller.annotation;
+
+import kr.co.ssalon.oauth2.CustomOAuth2Member;
+import kr.co.ssalon.web.dto.Oauth2MemberDto;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithCustomMockUserSecurityContextFactory implements WithSecurityContextFactory<WithCustomMockUser> {
+    @Override
+    public SecurityContext createSecurityContext(WithCustomMockUser withCustomMockUser) {
+        String username = withCustomMockUser.username();
+        String email = withCustomMockUser.email();
+        String role = withCustomMockUser.role();
+
+        Oauth2MemberDto oauth2MemberDto = Oauth2MemberDto.builder()
+                .username(username)
+                .role(role)
+                .email(email)
+                .build();
+        CustomOAuth2Member customOAuth2Member = new CustomOAuth2Member(oauth2MemberDto);
+
+        UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(customOAuth2Member, null, customOAuth2Member.getAuthorities());
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(authenticationToken);
+        return context;
+    }
+}


### PR DESCRIPTION
Controller, Service, Repository 각각에 대한 테스트 코드를 작성하였습니다.

Controller 테스트 시, 기존의 @WithMockUser 대신 @WithCustomMockUser 어노테이션을 사용하였습니다.
자세한 사항은 커밋 메시지 참고 바랍니다.