### PR TITLE
test: 로그인 테스트 코드 추가

### DIFF
--- a/back-end/src/main/java/kr/co/ssalon/domain/service/MemberService.java
+++ b/back-end/src/main/java/kr/co/ssalon/domain/service/MemberService.java
@@ -17,18 +17,19 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public Long register(String username, String email, String role) throws Exception {
+    public Member register(String username, String email, String role) throws Exception {
         validationUsername(username);
         Member member = Member.createMember(username, email, role);
-        memberRepository.save(member);
-        return member.getId();
+        member = memberRepository.save(member);
+        return member;
     }
     @Transactional
-    public void oauthUpdate(String username, String email, String role) throws BadRequestException {
+    public Member oauthUpdate(String username, String email, String role) throws BadRequestException {
         Optional<Member> findMember = memberRepository.findByUsername(username);
         Member member = validationMember(findMember);
         member.changeEmail(email);
         member.changeRole(role);
+        return member;
     }
 
 

--- a/back-end/src/test/java/kr/co/ssalon/domain/repository/RedisRefreshTokenRepositoryTest.java
+++ b/back-end/src/test/java/kr/co/ssalon/domain/repository/RedisRefreshTokenRepositoryTest.java
@@ -1,0 +1,104 @@
+package kr.co.ssalon.domain.repository;
+
+import kr.co.ssalon.jwt.RedisRefreshToken;
+import kr.co.ssalon.jwt.RedisRefreshTokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithMockUser;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataRedisTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class RedisRefreshTokenRepositoryTest {
+
+    @Autowired
+    RedisRefreshTokenRepository redisRefreshTokenRepository;
+
+    String refresh = "aaaaaaaaaaaaabbbbbbbbbbbbbbbbbbcccccccccccccccccc";
+
+    RedisRefreshToken redisRefreshToken = null;
+
+    @BeforeEach
+    public void getUsername() {
+        // DB 초기화
+        redisRefreshTokenRepository.deleteAll();
+
+        // 현재 소셜 로그인한 유저(@WithMockUser) 조회
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String username = authentication.getName();
+
+        // refresh 토큰 객체 생성
+        redisRefreshToken = new RedisRefreshToken();
+        redisRefreshToken.setUsername(username);
+        redisRefreshToken.setRefresh(refresh);
+    }
+
+    @Test
+    @DisplayName("RedisRefreshTokenRepository.save() 테스트")
+    @WithMockUser(username = "test") // 테스트 유저 인증 정보
+    public void redis에refreshToken저장() {
+        // given
+
+        // when (Redis에 토큰 저장)
+        redisRefreshToken = redisRefreshTokenRepository.save(redisRefreshToken);
+
+        // then
+        assertThat(redisRefreshToken.getRefresh()).isEqualTo(refresh);
+    }
+
+    @Test
+    @DisplayName("RedisRefreshTokenRepository.delete() 테스트")
+    @WithMockUser(username = "test") // 테스트 유저 인증 정보
+    public void refreshToken삭제() {
+        // given
+
+        // refresh 토큰이 redis에 저장되어 있다고 가정
+        redisRefreshTokenRepository.save(redisRefreshToken);
+
+        // when (Redis에 있는 refresh 토큰 제거)
+        redisRefreshTokenRepository.delete(redisRefreshToken);
+
+        // then
+        assertThat(redisRefreshTokenRepository.existsByRefresh(refresh)).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("RedisRefreshTokenRepository.existsByRefresh() 테스트")
+    @WithMockUser(username = "test") // 테스트 유저 인증 정보
+    public void refresh토큰존재여부확인() {
+        // given
+
+        // refresh 토큰이 redis에 저장되어 있다고 가정
+        redisRefreshTokenRepository.save(redisRefreshToken);
+
+        // when (refresh 토큰 존재 여부 확인)
+        boolean exist = redisRefreshTokenRepository.existsByRefresh(refresh);
+
+        // then
+        assertThat(exist).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("RedisRefreshTokenRepository.findByRefresh() 테스트")
+    @WithMockUser(username = "test") // 테스트 유저 인증 정보
+    public void 저장되어있는refresh토큰조회() {
+        // given
+
+        // refresh 토큰이 redis에 저장되어 있다고 가정
+        redisRefreshTokenRepository.save(redisRefreshToken);
+
+        // when (refresh 토큰 조회)
+        RedisRefreshToken savedRedisRefreshToken = redisRefreshTokenRepository.findByRefresh(refresh);
+
+        // then
+        assertThat(savedRedisRefreshToken.getRefresh()).isEqualTo(refresh);
+    }
+}

--- a/back-end/src/test/java/kr/co/ssalon/domain/service/MemberServiceTest.java
+++ b/back-end/src/test/java/kr/co/ssalon/domain/service/MemberServiceTest.java
@@ -5,6 +5,9 @@ import kr.co.ssalon.domain.entity.Region;
 import kr.co.ssalon.domain.repository.MemberRepository;
 import kr.co.ssalon.web.dto.MemberDTO;
 import org.apache.coyote.BadRequestException;
+import kr.co.ssalon.oauth2.CustomOAuth2Member;
+import kr.co.ssalon.web.controller.annotation.WithCustomMockUser;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,7 +15,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.ArrayList;
@@ -20,6 +22,11 @@ import java.util.Arrays;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.*;
+
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
@@ -31,16 +38,34 @@ public class MemberServiceTest {
     @InjectMocks
     private MemberService memberService;
 
+    String username = "";
+    String email = "";
+    String role = "";
+
+    @BeforeEach
+    public void getUsernameAndEmailAndRole() {
+        // 소셜로부터 가져온 유저(@WithMockUser)의 username, email, role 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomOAuth2Member customOAuth2Member = (CustomOAuth2Member) authentication.getPrincipal();
+
+        // username 추출
+        username = customOAuth2Member.getUsername();
+
+        // email 추출
+        email = customOAuth2Member.getEmail();
+
+        // role 추출
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+        role = auth.getAuthority();
+    }
 
     @Test
     @DisplayName("MemberService.signup() 테스트")
-    @WithMockUser(username = "test")
+    @WithCustomMockUser(username = "username", email = "email@email.com",  role = "ROLE_USER")
     public void 회원가입() throws BadRequestException {
         // given
-
-        // 현재 소셜 로그인한 유저(@WithMockUser) 객체 가져오기
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String username = authentication.getName();
 
         //   MemberRepository.findByUsername() stub
         Member member = Member.createMember("test", "test@test.com", "ROLE_USER");
@@ -61,5 +86,46 @@ public class MemberServiceTest {
         assertThat(joinedMember.getNickname()).isEqualTo("닉네임");
         assertThat(joinedMember.getInterests()).isEqualTo(new ArrayList<>(Arrays.asList("독서", "영화감상")));
         assertThat(joinedMember.getAddress()).isEqualTo(Region.GANGWONDO.getLocalName());
+    }
+
+    @Test
+    @DisplayName("MemberService.register() 테스트")
+    @WithCustomMockUser(username = "username", email = "email@email.com",  role = "ROLE_USER")
+    public void 소셜로그인등록() throws Exception {
+        // given
+
+        // MemberRepository.save() stub
+        Member socialLoginMember = Member.createMember(username, email, role);
+        when(memberRepository.save(any())).thenReturn(socialLoginMember);
+
+        // when (소셜 로그인 등록)
+        Member member = memberService.register(username, email, role);
+
+        // then (등록된 소셜 확인)
+        assertThat(member.getUsername()).isEqualTo(username);
+        assertThat(member.getEmail()).isEqualTo(email);
+        assertThat(member.getRole()).isEqualTo(role);
+    }
+
+    @Test
+    @DisplayName("MemberService.oauthUpdate() 테스트")
+    @WithCustomMockUser(username = "username", email = "email@email.com",  role = "ROLE_USER")
+    public void 소셜정보업데이트() throws Exception {
+        // given
+
+        // MemberRepository.save() stub
+        Member socialLoginMember = Member.createMember(username, email, role);
+        when(memberRepository.save(any())).thenReturn(socialLoginMember);
+
+        // MemberRepository.findByUsername stub
+        when(memberRepository.findByUsername(username)).thenReturn(Optional.of(socialLoginMember));
+
+        // when (소셜 로그인 정보 업데이트)
+        Member member = memberService.oauthUpdate(username, email, role);
+
+        // then (업데이트된 소셜 정보 확인)
+        assertThat(member.getUsername()).isEqualTo(username);
+        assertThat(member.getEmail()).isEqualTo(email);
+        assertThat(member.getRole()).isEqualTo(role);
     }
 }

--- a/back-end/src/test/java/kr/co/ssalon/jwt/JWTFilterTest.java
+++ b/back-end/src/test/java/kr/co/ssalon/jwt/JWTFilterTest.java
@@ -1,0 +1,78 @@
+package kr.co.ssalon.jwt;
+
+import jakarta.servlet.FilterChain;
+import kr.co.ssalon.web.controller.annotation.WithCustomMockUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+public class JWTFilterTest {
+
+    JWTUtil jwtUtil = new JWTUtil("ddddddddddbbbbbbbbbbbbcccccccccccc");
+
+    JWTFilter jwtFilter = new JWTFilter(jwtUtil);
+
+    static String username = "";
+    static String role = "";
+
+    @BeforeEach
+    public void getUsernameAndRole() {
+        // 현재 로그인된 유저(@WithCustomMockUser)의 username, role 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // username 추출
+        username = authentication.getName();
+
+        // role 추출
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+        role = auth.getAuthority();
+    }
+
+    @Test
+    @WithCustomMockUser(username = "naver", role = "ROLE_USER")
+    public void jwtFilter진행확인() throws Exception {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain filterChain = Mockito.mock(FilterChain.class);
+
+        // 유효한 JWT 토큰 생성
+        String access = jwtUtil.createJwt("access", username, role, 600000L);
+        request.addHeader("Authorization", "Bearer " + access);
+
+        // when (jwtFilter 필터 진행)
+        jwtFilter.doFilterInternal(request, response, filterChain);
+
+        // then (authentication에 유저 세션이 저장되었는지 확인)
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // username 추출
+        String username = authentication.getName();
+        // role 추출
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        String extractedRole = authorities.iterator().next().getAuthority();
+
+        assertThat(authentication).isNotNull();
+        assertThat(authentication.isAuthenticated()).isTrue();
+        assertThat(authentication.getName()).isEqualTo(username);
+        assertThat(extractedRole).isEqualTo(role);
+
+        // filterChain.doFilter(=다음 필터로 진행)가 호출되었는지 확인
+        Mockito.verify(filterChain).doFilter(request, response);
+    }
+}

--- a/back-end/src/test/java/kr/co/ssalon/jwt/JWTUtilTest.java
+++ b/back-end/src/test/java/kr/co/ssalon/jwt/JWTUtilTest.java
@@ -1,0 +1,116 @@
+package kr.co.ssalon.jwt;
+
+import kr.co.ssalon.web.controller.annotation.WithCustomMockUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@WithCustomMockUser(username = "naver", role = "ROLE_USER")
+public class JWTUtilTest {
+
+    JWTUtil jwtUtil = new JWTUtil("ddddddddddbbbbbbbbbbbbcccccccccccc");
+
+    static String username = "";
+    static String role = "";
+
+    @BeforeEach
+    public void getUsernameAndRole() {
+        // 현재 로그인된 유저(@WithCustomMockUser)의 username, role 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // username 추출
+        username = authentication.getName();
+
+        // role 추출
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+        role = auth.getAuthority();
+    }
+
+    @Test
+    @DisplayName("JWTUtil.getUsername() 테스트")
+    public void getUsername() {
+        // given
+
+        // access token 생성
+        String token = jwtUtil.createJwt("access", username, role, 6000000L);
+
+        // when (username 추출)
+        String extractedUsername = jwtUtil.getUsername(token);
+
+        // then
+        assertThat(extractedUsername).isEqualTo(username);
+    }
+
+    @Test
+    @DisplayName("JWTUtil.getRole() 테스트")
+    public void getRole() {
+        // given
+
+        // access token 생성
+        String token = jwtUtil.createJwt("access", username, role, 6000000L);
+
+        // when (role 추출)
+        String extractedRole = jwtUtil.getRole(token);
+
+        // then
+        assertThat(extractedRole).isEqualTo(role);
+    }
+
+    @Test
+    @DisplayName("JWTUtil.getCategory() 테스트")
+    public void getCategory() {
+        // given
+
+        // access token 생성
+        String category = "access";
+        String token = jwtUtil.createJwt(category, username, role, 6000000L);
+
+        // when (category 테스트)
+        String extractedCategory = jwtUtil.getCategory(token);
+
+        // then
+        assertThat(extractedCategory).isEqualTo(category);
+    }
+
+    @Test
+    @DisplayName("JWTUtil.isExpired() 테스트")
+    public void isExpired() {
+        // given
+
+        // access token 생성
+        String token = jwtUtil.createJwt("access", username, role, 6000000L);
+
+        // when (isExpired 테스트)
+        Boolean isExpired = jwtUtil.isExpired(token);
+
+        // then
+        assertThat(isExpired).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("JWTUtil.createJwt() 테스트")
+    public void createJwt() {
+        // given
+
+        // when (createJwt 테스트)
+        String token = jwtUtil.createJwt("access", username, role, 6000000L);
+
+        // then
+        assertThat(jwtUtil.getUsername(token)).isEqualTo(username);
+        assertThat(jwtUtil.getRole(token)).isEqualTo(role);
+
+    }
+}

--- a/back-end/src/test/java/kr/co/ssalon/oauth2/handler/CustomSuccessHandlerTest.java
+++ b/back-end/src/test/java/kr/co/ssalon/oauth2/handler/CustomSuccessHandlerTest.java
@@ -1,0 +1,85 @@
+package kr.co.ssalon.oauth2.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.co.ssalon.jwt.JWTUtil;
+import kr.co.ssalon.jwt.RedisRefreshTokenRepository;
+import kr.co.ssalon.oauth2.CustomOAuth2Member;
+import kr.co.ssalon.web.controller.annotation.WithCustomMockUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.Iterator;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+public class CustomSuccessHandlerTest {
+
+    @Mock
+    private JWTUtil jwtUtil;
+
+    @Mock
+    private RedisRefreshTokenRepository redisRefreshTokenRepository;
+
+    @InjectMocks
+    private CustomSuccessHandler customSuccessHandler;
+
+    Authentication authentication = null;
+
+    static String username = "";
+    static String role = "";
+
+    @BeforeEach
+    public void getUsernameAndRole() {
+        // 소셜로부터 가져온 유저(@WithCustomMockUser)의 username, role 가져오기
+        authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomOAuth2Member customOAuth2Member = (CustomOAuth2Member) authentication.getPrincipal();
+
+        // username 추출
+        username = customOAuth2Member.getUsername();
+
+        // role 추출
+        Collection<? extends GrantedAuthority> authorities = customOAuth2Member.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+        role = auth.getAuthority();
+    }
+
+    @Test
+    @WithCustomMockUser
+    public void 토큰response() throws Exception {
+        // given
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        PrintWriter writer = mock(PrintWriter.class);
+
+        // JWTUtil stub
+        String access = "mock_access_token";
+        String refresh = "mock_refresh_token";
+        when(jwtUtil.createJwt("access", username, role, 600000L)).thenReturn(access);
+        when(jwtUtil.createJwt("refresh", username, role, 86400000L)).thenReturn(refresh);
+
+        // response.getWriter() stub
+        when(response.getWriter()).thenReturn(writer);
+
+        // when
+        customSuccessHandler.onAuthenticationSuccess(request, response, authentication);
+
+        // then
+        verify(response).setContentType("application/json");
+        verify(response).setStatus(HttpStatus.OK.value());
+        verify(writer).print("{\"access\":\"" + access + "\",\"refresh\":\"" + refresh + "\"}");
+        verify(writer).flush();
+    }
+}

--- a/back-end/src/test/java/kr/co/ssalon/web/controller/ReissueControllerTest.java
+++ b/back-end/src/test/java/kr/co/ssalon/web/controller/ReissueControllerTest.java
@@ -1,0 +1,89 @@
+package kr.co.ssalon.web.controller;
+
+import kr.co.ssalon.jwt.JWTUtil;
+import kr.co.ssalon.jwt.RedisRefreshTokenRepository;
+import kr.co.ssalon.web.controller.annotation.WithCustomMockUser;
+import kr.co.ssalon.web.controller.oauth2.ReissueController;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ReissueController.class)
+public class ReissueControllerTest {
+
+    @MockBean
+    private RedisRefreshTokenRepository redisRefreshTokenRepository;
+
+    @MockBean
+    JWTUtil jwtUtil;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    String username = "";
+    String role = "";
+
+    @BeforeEach
+    public void getUsernameAndRole() {
+        // 현재 로그인된 유저(@WithCustomMockUser)의 username, role 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // username 추출
+        username = authentication.getName();
+
+        // role 추출
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+        role = auth.getAuthority();
+    }
+
+    @Test
+    @DisplayName("access 토큰 재발급 API(POST /api/reissue) 테스트")
+    @WithCustomMockUser(username = "user1", role = "ROLE_USER")
+    public void access토큰재발급() throws Exception {
+        // given
+
+        // JwtUtil stub
+        String previousRefresh = "previous refresh token";
+        String newAccess = "new access token";
+        String newRefresh = "new refresh token";
+        when(jwtUtil.isExpired(previousRefresh)).thenReturn(false);
+        when(jwtUtil.getCategory(previousRefresh)).thenReturn("refresh");
+        when(jwtUtil.getUsername(previousRefresh)).thenReturn(username);
+        when(jwtUtil.getRole(previousRefresh)).thenReturn(role);
+        when(jwtUtil.createJwt("access", username, role, 600000L)).thenReturn(newAccess);
+        when(jwtUtil.createJwt("refresh", username, role, 86400000L)).thenReturn(newRefresh);
+
+        // RedisRefreshTokenRepository.existsByRefresh() stub
+        when(redisRefreshTokenRepository.existsByRefresh(previousRefresh)).thenReturn(true);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.post("/api/reissue")
+                .with(csrf())
+                .header("Refresh", previousRefresh));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.access", is(newAccess)))
+                .andExpect(jsonPath("$.refresh", is(newRefresh)));
+    }
+}


### PR DESCRIPTION
아래 내용과 관련된 클래스 및 메소드를 테스트하는 테스트 코드를 추가하였습니다.

- Refresh Token을 Redis에 저장
- 소셜 정보 등록
- 소셜 정보 업데이트
- JWT로부터 정보를 추출하는 JWTUtil 내의 모든 메소드
- Access Token 재발급
- JWT 검증 필터
- Response Body에 JWT 추가