### PR TITLE
test: 모임 참가 테스트 코드 추가

### DIFF
--- a/back-end/src/test/java/kr/co/ssalon/domain/repository/MeetingRepositoryTest.java
+++ b/back-end/src/test/java/kr/co/ssalon/domain/repository/MeetingRepositoryTest.java
@@ -4,6 +4,7 @@ import kr.co.ssalon.domain.entity.Category;
 import kr.co.ssalon.domain.entity.Meeting;
 import kr.co.ssalon.domain.entity.Region;
 import kr.co.ssalon.web.dto.MeetingSearchCondition;
+import org.apache.coyote.BadRequestException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,12 +12,9 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.transaction.annotation.Transactional;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -64,5 +62,28 @@ public class MeetingRepositoryTest {
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getContent().get(0).getLocation()).isEqualTo("서울특별시");
         assertThat(result.getContent().get(0).getCategory().getName()).isEqualTo("운동");
+    }
+
+    @Test
+    @DisplayName("MeetingRepository.findById() 테스트")
+    public void id로특정모임조회() throws BadRequestException {
+        // given
+        Long moimId = 1L;
+
+        // moimId를 id로 가지는 모임을 테스트 DB에 저장
+        Meeting meeting = Meeting.builder()
+                .id(moimId)
+                .description("독서 모임입니다.")
+                .build();
+        meeting.setId(moimId);
+        meetingRepository.save(meeting);
+
+        // when
+        Meeting foundMeeting = meetingRepository.findById(moimId)
+                .orElseThrow(() -> new BadRequestException("해당 모임을 찾을 수 없습니다. ID: " + moimId));
+
+        // then
+        assertThat(foundMeeting.getId()).isEqualTo(moimId);
+        assertThat(foundMeeting.getDescription()).isEqualTo("독서 모임입니다.");
     }
 }

--- a/back-end/src/test/java/kr/co/ssalon/domain/service/MeetingServiceTest.java
+++ b/back-end/src/test/java/kr/co/ssalon/domain/service/MeetingServiceTest.java
@@ -1,30 +1,44 @@
 package kr.co.ssalon.domain.service;
 
-import kr.co.ssalon.domain.entity.Category;
-import kr.co.ssalon.domain.entity.Meeting;
-import kr.co.ssalon.domain.entity.Region;
+import kr.co.ssalon.domain.entity.*;
 import kr.co.ssalon.domain.repository.MeetingRepository;
+import kr.co.ssalon.domain.repository.MemberMeetingRepository;
+import kr.co.ssalon.oauth2.CustomOAuth2Member;
+import kr.co.ssalon.web.controller.annotation.WithCustomMockUser;
+import kr.co.ssalon.web.dto.MeetingDTO;
 import kr.co.ssalon.web.dto.MeetingSearchCondition;
+import org.apache.coyote.BadRequestException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
 import java.util.Collections;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith(SpringExtension.class)
 public class MeetingServiceTest {
 
     @Mock
     private MeetingRepository meetingRepository;
+
+    @Mock
+    private MemberMeetingRepository memberMeetingRepository;
+
+    @Mock
+    private MemberService memberService;
 
     @InjectMocks
     private MeetingService meetingService;
@@ -64,5 +78,45 @@ public class MeetingServiceTest {
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getContent().get(0).getLocation()).isEqualTo("서울특별시");
         assertThat(result.getContent().get(0).getCategory().getName()).isEqualTo("운동");
+    }
+
+    @Test
+    @DisplayName("MeetingService.join() 테스트")
+    @WithCustomMockUser
+    public void 모임참가() throws BadRequestException {
+        // given
+        Long moimId = 11111L;
+
+        // 현재 로그인된 사용자의 username, email, role 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomOAuth2Member customOAuth2Member = (CustomOAuth2Member) authentication.getPrincipal();
+
+        // Meeting Mock 객체 생성
+        Meeting meeting = mock(Meeting.class);
+        Category category = mock(Category.class);
+        Payment payment = mock(Payment.class);
+        Member creator = mock(Member.class);
+        Ticket ticket = mock(Ticket.class);
+        when(meeting.getCategory()).thenReturn(category);
+        when(meeting.getPayment()).thenReturn(payment);
+        when(meeting.getCreator()).thenReturn(creator);
+        when(meeting.getTicket()).thenReturn(ticket);
+        when(meeting.getDescription()).thenReturn("독서 모임입니다.");
+
+        // MemberService stub
+        Member currentUser = mock(Member.class);
+        when(memberService.findMember(anyString())).thenReturn(currentUser);
+
+        // MeetingRepository stub
+        when(meetingRepository.findById(anyLong())).thenReturn(Optional.ofNullable(meeting));
+
+        // MemberMeetingRepository stub
+        when(memberMeetingRepository.save(any())).thenReturn(any());
+
+        // when
+        MeetingDTO joinedMeeting = meetingService.join(customOAuth2Member, moimId);
+
+        // then
+        assertThat(joinedMeeting.getDescription()).isEqualTo("독서 모임입니다.");
     }
 }

--- a/back-end/src/test/java/kr/co/ssalon/web/controller/MeetingControllerTest.java
+++ b/back-end/src/test/java/kr/co/ssalon/web/controller/MeetingControllerTest.java
@@ -2,6 +2,8 @@ package kr.co.ssalon.web.controller;
 
 import kr.co.ssalon.domain.entity.*;
 import kr.co.ssalon.domain.service.MeetingService;
+import kr.co.ssalon.web.controller.annotation.WithCustomMockUser;
+import kr.co.ssalon.web.dto.MeetingDTO;
 import kr.co.ssalon.web.dto.MeetingSearchCondition;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,8 +20,10 @@ import java.util.Collections;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -82,5 +86,30 @@ public class MeetingControllerTest {
                 .andExpect(jsonPath("$", hasSize(1)))
                 .andExpect(jsonPath("$[0].location", is("서울특별시")));
 
+    }
+
+    @Test
+    @DisplayName("모임 참가 API(POST /api/moims/{moimId}/users) 테스트")
+    @WithCustomMockUser
+    public void 모임참가API() throws Exception {
+        // given
+        String moimId = "1";
+
+        MeetingDTO meetingDTO = MeetingDTO.builder()
+                .id(Long.parseLong(moimId))
+                .description("독서 모임입니다.")
+                .build();
+
+        // MeetingService stub
+        when(meetingService.join(any(), any())).thenReturn(meetingDTO);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.post("/api/moims/" + moimId + "/users")
+                .with(csrf()));
+
+        // then
+        resultActions.andExpect(status().isOk());
+        resultActions.andExpect(jsonPath("$.id", is(1)));
+        resultActions.andExpect(jsonPath("$.description", is("독서 모임입니다.")));
     }
 }


### PR DESCRIPTION
아래 메소드 및 API를 테스트하는 테스트 코드를 추가하였습니다

- MeetingRepository.findById()
- MeetingService.join()
- 모임 참가 API(POST /api/moims/{moimId}/users)