### PR TITLE
feat: 회원 탈퇴 API 추가

### DIFF
--- a/back-end/src/main/java/kr/co/ssalon/domain/entity/Meeting.java
+++ b/back-end/src/main/java/kr/co/ssalon/domain/entity/Meeting.java
@@ -36,7 +36,7 @@ public class Meeting {
     @JoinColumn(name = "ticket_id")
     private Ticket ticket;
 
-    @OneToMany(mappedBy = "meeting")
+    @OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<MemberMeeting> participants = new ArrayList<>();
 
     @ElementCollection

--- a/back-end/src/main/java/kr/co/ssalon/domain/entity/Member.java
+++ b/back-end/src/main/java/kr/co/ssalon/domain/entity/Member.java
@@ -19,10 +19,10 @@ public class Member {
     @Column(name = "member_id")
     private Long id;
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<MemberMeeting> joinedMeetings = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Payment> payments = new ArrayList<>();
 
 

--- a/back-end/src/main/java/kr/co/ssalon/web/controller/UserController.java
+++ b/back-end/src/main/java/kr/co/ssalon/web/controller/UserController.java
@@ -13,6 +13,7 @@ import kr.co.ssalon.web.dto.MemberSignDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.coyote.BadRequestException;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -71,5 +72,16 @@ public class UserController {
     @DeleteMapping("/api/auth/logout")
     public void logout() {
         // swagger logout API 작성용으로 만든 빈 메소드
+    }
+
+    @Operation(summary = "회원 탈퇴")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공"),
+    })
+    @DeleteMapping("/api/users/me")
+    public ResponseEntity<String> withdraw(@AuthenticationPrincipal CustomOAuth2Member customOAuth2Member) throws BadRequestException {
+        String username = customOAuth2Member.getUsername();
+        memberService.withdraw(username);
+        return ResponseEntity.ok("회원 탈퇴 성공");
     }
 }


### PR DESCRIPTION
`DELETE /api/users/me`

회원 탈퇴 전, Cascade 옵션을 통해 관련 데이터들을 함께 제거

> `CascadeType.REMOVE`: 부모 엔티티 삭제 시 자식 엔티티 자동 삭제
> `orphanRemoval = true`: `CascadeType.REMOVE` 성질을 포함. 부모 엔티티가 자식 엔티티와의 **_연관 관계 제거 시_** 고아 객체가 된 자식 엔티티 자동 삭제