### PR TITLE
feat: 다이어리 관련 기능 구현

### DIFF
--- a/back-end/src/main/java/kr/co/ssalon/domain/service/DiaryService.java
+++ b/back-end/src/main/java/kr/co/ssalon/domain/service/DiaryService.java
@@ -5,13 +5,18 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import kr.co.ssalon.web.dto.DiaryFetchResponseDTO;
 import kr.co.ssalon.web.dto.DiaryInitResponseDTO;
+import kr.co.ssalon.web.dto.TicketEditResponseDTO;
+import kr.co.ssalon.web.dto.TicketImageResponseDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 @Service
 public class DiaryService {
@@ -23,10 +28,10 @@ public class DiaryService {
     @Autowired
     private AwsS3Service awsS3Service;
 
-    public DiaryFetchResponseDTO fetchDiary(Long moimID, String userEmail) {
+    public DiaryFetchResponseDTO fetchDiary(Long moimID, String username) {
         // R of CRUD : 다이어리 조회
 
-        String resultJSON = awsS3Service.getFileAsJsonString(moimID.toString(), userEmail);
+        String resultJSON = awsS3Service.getFileAsJsonString(moimID.toString(), username);
 
         return DiaryFetchResponseDTO.builder()
                 .resultCode("200 OK")
@@ -34,7 +39,7 @@ public class DiaryService {
                 .build();
     }
 
-    public DiaryInitResponseDTO initDiary(Long moimID, String userEmail) {
+    public DiaryInitResponseDTO initDiary(Long moimID, String username) {
         // C of CRUD : 다이어리 생성
         // 템플릿 복제하여 최초 다이어리 생성
         String diaryJsonString = awsS3Service.getFileAsJsonString(DIARY_TEMPLATE_FOLDER);
@@ -43,13 +48,12 @@ public class DiaryService {
         Map<String, String> imageSrcMap = new HashMap<>();
 
         // JSON 파싱 및 수정 작업
-        String toLocation = moimID.toString() + "/" + userEmail;
-        JsonElement jsonElement = editDiaryJsonSrc(DIARY_TEMPLATE_FOLDER, toLocation, diaryJsonString, imageSrcMap);
+        JsonElement jsonElement = editDiaryJsonSrc(DIARY_TEMPLATE_FOLDER, moimID.toString(), username, diaryJsonString, imageSrcMap);
 
         // 이제 수정된 JSON 업로드 필요
         // 이후 JSON 내용과 동일하게 이미지 파일 복제 및 이름 변경 작업 진행
         // ** 추후 고려 : 중간에 실패한다면? **
-        String resultJson = awsS3Service.uploadFileViaStream(moimID, userEmail, jsonElement.toString());   // JSON 업로드
+        String resultJson = awsS3Service.uploadFileViaStream(moimID, username, jsonElement.toString());   // JSON 업로드
         List<String> resultCopy = awsS3Service.copyFilesFromTemplate(imageSrcMap);              // JSON 기반 정적 파일 복제
 
         return DiaryInitResponseDTO.builder()
@@ -59,7 +63,7 @@ public class DiaryService {
                 .build();
     }
 
-    public String editDiary(Long moimId, String userEmail, String json) {
+    public TicketEditResponseDTO editDiary(Long moimId, String username, String json) {
         // 주어진 모임ID 바탕으로 다이어리 업로드 내용 수정
         // 현재(240512)는 기존 내용 삭제 후 새로 업로드
         // 추후 : 이전 다이어리 수정 기록 보존을 고려할 것
@@ -69,14 +73,62 @@ public class DiaryService {
 
         // JSON src 수정 후 업로드 진행
         Map<String, String> imageSrcMap = new HashMap<>();
-        JsonElement jsonElement = editDiaryJsonSrc(moimId.toString(), moimId.toString(), json, imageSrcMap);
-        String resultJson = awsS3Service.uploadFileViaStream(moimId, userEmail, jsonElement.toString());
+        JsonElement jsonElement = editDiaryJsonSrc(moimId.toString(), moimId.toString(), username, json, imageSrcMap);
+        String resultJson = awsS3Service.uploadFileViaStream(moimId, username, jsonElement.toString());
 
         // 결과 반환
-        return null; //new TicketEditResponseDTO(resultJson, jsonElement.toString());
+        return new TicketEditResponseDTO(resultJson, jsonElement.toString());
     }
 
-    private JsonElement editDiaryJsonSrc(String fromMoimId, String toMoimId, String jsonStr, Map<String, String> imageSrcMap) {
+    @Transactional
+    public TicketImageResponseDTO uploadImages(Long moimId, List<MultipartFile> multipartFiles) {
+
+        Map<String, String> imageSrcMap = new HashMap<>();
+
+        int requestSize = multipartFiles.size();
+
+        if (requestSize == 0) return TicketImageResponseDTO.builder()
+                .resultCode("400 Bad Request")
+                .numRequest(requestSize)
+                .numResult(0)
+                .mapURI(null)
+                .build();
+
+        for (MultipartFile multipartFile : multipartFiles) {
+            String oldFileURI = multipartFile.getOriginalFilename();
+            String extOldFile = oldFileURI.substring(oldFileURI.lastIndexOf('.') + 1);
+            String newFileURI = moimId.toString() + "/" + generateRandomUUID() + "." + extOldFile;
+
+            imageSrcMap.put(oldFileURI, newFileURI);
+        }
+
+        int resultSize = awsS3Service.uploadMultiFilesViaMultipart(multipartFiles, imageSrcMap);
+
+        if (requestSize == resultSize) return TicketImageResponseDTO.builder()
+                .resultCode("201 Created")
+                .numRequest(requestSize)
+                .numResult(resultSize)
+                .mapURI(imageSrcMap)
+                .build();
+        else if (resultSize > 0) return TicketImageResponseDTO.builder()
+                .resultCode("206 Partial Content")
+                .numRequest(requestSize)
+                .numResult(resultSize)
+                .mapURI(imageSrcMap)
+                .build();
+        else return TicketImageResponseDTO.builder()
+                    .resultCode("502 Bad Gateway")
+                    .numRequest(requestSize)
+                    .numResult(resultSize)
+                    .mapURI(imageSrcMap)
+                    .build();
+    }
+
+    private String generateRandomUUID() {
+        return UUID.randomUUID().toString();
+    }
+
+    private JsonElement editDiaryJsonSrc(String fromMoimId, String toMoimId, String username, String jsonStr, Map<String, String> imageSrcMap) {
         // 목표 : 키 파싱 설계를 좀더 Portable 하게 수정하기
 
         // JSON 파일 이름 대조하여 변경 작업
@@ -86,7 +138,7 @@ public class DiaryService {
         // thumbnail 이미지 파일 이름 수정
         String urlThumb = topLevelObject.get("thumbnailUrl").getAsString();
         String extFile = urlThumb.substring(urlThumb.lastIndexOf('.') + 1);
-        String newThumbURI = "Thumbnails/" + toMoimId + "/Thumb-" + toMoimId + "." + extFile;
+        String newThumbURI = "Thumbnails/" + toMoimId + "/Thumb-" + username + "." + extFile;
         String oldThumbURI = "Thumbnails/" + fromMoimId + "/" + urlThumb.substring(urlThumb.lastIndexOf('/') + 1);
 
         imageSrcMap.put(oldThumbURI, newThumbURI);

--- a/back-end/src/main/java/kr/co/ssalon/domain/service/DiaryService.java
+++ b/back-end/src/main/java/kr/co/ssalon/domain/service/DiaryService.java
@@ -1,0 +1,97 @@
+package kr.co.ssalon.domain.service;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import kr.co.ssalon.web.dto.DiaryFetchResponseDTO;
+import kr.co.ssalon.web.dto.DiaryInitResponseDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class DiaryService {
+
+    @Value("${spring.cloud.aws.s3.endpoint}")
+    private String AWS_S3_ASSET_URI;
+    private final String DIARY_TEMPLATE_FOLDER = "DIARY-TEMPLATE";
+
+    @Autowired
+    private AwsS3Service awsS3Service;
+
+    public DiaryFetchResponseDTO fetchDiary(Long moimID, String userEmail) {
+        // R of CRUD : 다이어리 조회
+
+        String resultJSON = awsS3Service.getFileAsJsonString(moimID.toString(), userEmail);
+
+        return DiaryFetchResponseDTO.builder()
+                .resultCode("200 OK")
+                .resultJSON(resultJSON)
+                .build();
+    }
+
+    public DiaryInitResponseDTO initDiary(Long moimID, String userEmail) {
+        // C of CRUD : 다이어리 생성
+        // 템플릿 복제하여 최초 다이어리 생성
+        String diaryJsonString = awsS3Service.getFileAsJsonString(DIARY_TEMPLATE_FOLDER);
+
+        // JSON 내 src 구주소:신주소 기록용 Map 생성
+        Map<String, String> imageSrcMap = new HashMap<>();
+
+        // JSON 파싱 및 수정 작업
+        String toLocation = moimID.toString() + "/" + userEmail;
+        JsonElement jsonElement = editDiaryJsonSrc(DIARY_TEMPLATE_FOLDER, toLocation, diaryJsonString, imageSrcMap);
+
+        // 이제 수정된 JSON 업로드 필요
+        // 이후 JSON 내용과 동일하게 이미지 파일 복제 및 이름 변경 작업 진행
+        // ** 추후 고려 : 중간에 실패한다면? **
+        String resultJson = awsS3Service.uploadFileViaStream(moimID, userEmail, jsonElement.toString());   // JSON 업로드
+        List<String> resultCopy = awsS3Service.copyFilesFromTemplate(imageSrcMap);              // JSON 기반 정적 파일 복제
+
+        return DiaryInitResponseDTO.builder()
+                .resultCode("201 Created")
+                .resultJsonUpload(resultJson)
+                .resultCopyFiles(resultCopy)
+                .build();
+    }
+
+    public String editDiary(Long moimId, String userEmail, String json) {
+        // 주어진 모임ID 바탕으로 다이어리 업로드 내용 수정
+        // 현재(240512)는 기존 내용 삭제 후 새로 업로드
+        // 추후 : 이전 다이어리 수정 기록 보존을 고려할 것
+
+        // 임시 정책 : 일단 기존 파일은 내버려두고, 새 파일 생성
+        // 추후 고려 정책 : 먼저, 기존 파일들 전부 삭제
+
+        // JSON src 수정 후 업로드 진행
+        Map<String, String> imageSrcMap = new HashMap<>();
+        JsonElement jsonElement = editDiaryJsonSrc(moimId.toString(), moimId.toString(), json, imageSrcMap);
+        String resultJson = awsS3Service.uploadFileViaStream(moimId, userEmail, jsonElement.toString());
+
+        // 결과 반환
+        return null; //new TicketEditResponseDTO(resultJson, jsonElement.toString());
+    }
+
+    private JsonElement editDiaryJsonSrc(String fromMoimId, String toMoimId, String jsonStr, Map<String, String> imageSrcMap) {
+        // 목표 : 키 파싱 설계를 좀더 Portable 하게 수정하기
+
+        // JSON 파일 이름 대조하여 변경 작업
+        JsonElement jsonElement = JsonParser.parseString(jsonStr);
+        JsonObject topLevelObject = jsonElement.getAsJsonObject();
+
+        // thumbnail 이미지 파일 이름 수정
+        String urlThumb = topLevelObject.get("thumbnailUrl").getAsString();
+        String extFile = urlThumb.substring(urlThumb.lastIndexOf('.') + 1);
+        String newThumbURI = "Thumbnails/" + toMoimId + "/Thumb-" + toMoimId + "." + extFile;
+        String oldThumbURI = "Thumbnails/" + fromMoimId + "/" + urlThumb.substring(urlThumb.lastIndexOf('/') + 1);
+
+        imageSrcMap.put(oldThumbURI, newThumbURI);
+        topLevelObject.addProperty("thumbnailUrl", AWS_S3_ASSET_URI + newThumbURI);
+
+        return jsonElement;
+    }
+}

--- a/back-end/src/main/java/kr/co/ssalon/web/controller/DiaryController.java
+++ b/back-end/src/main/java/kr/co/ssalon/web/controller/DiaryController.java
@@ -1,0 +1,65 @@
+package kr.co.ssalon.web.controller;
+
+import kr.co.ssalon.domain.service.DiaryService;
+import kr.co.ssalon.oauth2.CustomOAuth2Member;
+import kr.co.ssalon.web.dto.DiaryFetchResponseDTO;
+import kr.co.ssalon.web.dto.DiaryInitResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.URI;
+import java.util.List;
+
+// DiaryController : 증표 뒷면(일기) 관련 API
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/tickets")
+public class DiaryController {
+
+    @Autowired
+    private DiaryService diaryService;
+
+    @GetMapping("/{moimId}/diary") // R of CRUD : 다이어리 조회
+    public ResponseEntity<DiaryFetchResponseDTO> fetchDiary(@AuthenticationPrincipal CustomOAuth2Member customOAuth2Member, @PathVariable Long moimId) {
+
+        String userEmail = customOAuth2Member.getEmail();
+        DiaryFetchResponseDTO diaryFetchResponseDTO = diaryService.fetchDiary(moimId, userEmail);
+
+        if (diaryFetchResponseDTO.getResultCode().equals("200 OK")) return ResponseEntity.ok(diaryFetchResponseDTO);
+        else return ResponseEntity.badRequest().build();
+    }
+
+    @PostMapping("/{moimId}/diary") // C of CRUD : 다이어리 생성
+    public ResponseEntity<String> createDiary(@AuthenticationPrincipal CustomOAuth2Member customOAuth2Member, @PathVariable Long moimId) {
+
+        String userEmail = customOAuth2Member.getEmail();
+        DiaryInitResponseDTO diaryInitResponseDTO = diaryService.initDiary(moimId, userEmail);
+
+        if (diaryInitResponseDTO.getResultCode().equals("201 Created")) return ResponseEntity.created(URI.create("/"+moimId+"/diary/"+userEmail)).body(diaryInitResponseDTO.toString());
+        else return ResponseEntity.badRequest().build();
+    }
+
+    @PutMapping("/{moimId}/diary") // U of CRUD : 다이어리 편집
+    public ResponseEntity<String> editDiary(@AuthenticationPrincipal CustomOAuth2Member customOAuth2Member, @PathVariable Long moimId, @RequestPart String json) {
+
+        String userEmail = customOAuth2Member.getEmail();
+        diaryService.editDiary(moimId, userEmail, json);
+
+        return null;
+    }
+
+    @PostMapping("/{moimId}/diary/image") // U of CRUD : 다이어리 편집을 위한 이미지 업로드
+    public ResponseEntity<String> uploadDiaryImage(@AuthenticationPrincipal CustomOAuth2Member customOAuth2Member, @PathVariable Long moimId, @RequestPart List<MultipartFile> files) {
+
+        return null;
+    }
+
+    @DeleteMapping("/{moimId}/diary") // D of CRUD : 다이어리 삭제
+    public ResponseEntity<String> deleteDiary(@AuthenticationPrincipal CustomOAuth2Member customOAuth2Member, @PathVariable Long moimId) {
+        return null;
+    }
+}

--- a/back-end/src/main/java/kr/co/ssalon/web/controller/DiaryController.java
+++ b/back-end/src/main/java/kr/co/ssalon/web/controller/DiaryController.java
@@ -4,8 +4,11 @@ import kr.co.ssalon.domain.service.DiaryService;
 import kr.co.ssalon.oauth2.CustomOAuth2Member;
 import kr.co.ssalon.web.dto.DiaryFetchResponseDTO;
 import kr.co.ssalon.web.dto.DiaryInitResponseDTO;
+import kr.co.ssalon.web.dto.TicketEditResponseDTO;
+import kr.co.ssalon.web.dto.TicketImageResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -17,49 +20,62 @@ import java.util.List;
 // DiaryController : 증표 뒷면(일기) 관련 API
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/tickets")
+@RequestMapping("/api/diary")
 public class DiaryController {
 
     @Autowired
     private DiaryService diaryService;
 
-    @GetMapping("/{moimId}/diary") // R of CRUD : 다이어리 조회
+    @GetMapping("/{moimId}") // R of CRUD : 다이어리 조회
     public ResponseEntity<DiaryFetchResponseDTO> fetchDiary(@AuthenticationPrincipal CustomOAuth2Member customOAuth2Member, @PathVariable Long moimId) {
 
-        String userEmail = customOAuth2Member.getEmail();
-        DiaryFetchResponseDTO diaryFetchResponseDTO = diaryService.fetchDiary(moimId, userEmail);
+        String username = usernameConverter(customOAuth2Member.getUsername());
+        DiaryFetchResponseDTO diaryFetchResponseDTO = diaryService.fetchDiary(moimId, username);
 
         if (diaryFetchResponseDTO.getResultCode().equals("200 OK")) return ResponseEntity.ok(diaryFetchResponseDTO);
         else return ResponseEntity.badRequest().build();
     }
 
-    @PostMapping("/{moimId}/diary") // C of CRUD : 다이어리 생성
+    @PostMapping("/{moimId}") // C of CRUD : 다이어리 생성
     public ResponseEntity<String> createDiary(@AuthenticationPrincipal CustomOAuth2Member customOAuth2Member, @PathVariable Long moimId) {
 
-        String userEmail = customOAuth2Member.getEmail();
-        DiaryInitResponseDTO diaryInitResponseDTO = diaryService.initDiary(moimId, userEmail);
+        String username = usernameConverter(customOAuth2Member.getUsername());
+        DiaryInitResponseDTO diaryInitResponseDTO = diaryService.initDiary(moimId, username);
 
-        if (diaryInitResponseDTO.getResultCode().equals("201 Created")) return ResponseEntity.created(URI.create("/"+moimId+"/diary/"+userEmail)).body(diaryInitResponseDTO.toString());
+        if (diaryInitResponseDTO.getResultCode().equals("201 Created")) return ResponseEntity.created(URI.create("/"+moimId+"/"+username)).body(diaryInitResponseDTO.toString());
         else return ResponseEntity.badRequest().build();
     }
 
-    @PutMapping("/{moimId}/diary") // U of CRUD : 다이어리 편집
-    public ResponseEntity<String> editDiary(@AuthenticationPrincipal CustomOAuth2Member customOAuth2Member, @PathVariable Long moimId, @RequestPart String json) {
+    @PutMapping("/{moimId}") // U of CRUD : 다이어리 편집
+    public ResponseEntity<TicketEditResponseDTO> editDiary(@AuthenticationPrincipal CustomOAuth2Member customOAuth2Member, @PathVariable Long moimId, @RequestPart String json) {
 
-        String userEmail = customOAuth2Member.getEmail();
-        diaryService.editDiary(moimId, userEmail, json);
+        String username = usernameConverter(customOAuth2Member.getUsername());
+        TicketEditResponseDTO ticketEditResponseDTO = diaryService.editDiary(moimId, username, json);
 
-        return null;
+        if (ticketEditResponseDTO.getResultJson().equals("200 OK")) return ResponseEntity.ok(ticketEditResponseDTO);
+        else return ResponseEntity.badRequest().body(ticketEditResponseDTO);
     }
 
-    @PostMapping("/{moimId}/diary/image") // U of CRUD : 다이어리 편집을 위한 이미지 업로드
-    public ResponseEntity<String> uploadDiaryImage(@AuthenticationPrincipal CustomOAuth2Member customOAuth2Member, @PathVariable Long moimId, @RequestPart List<MultipartFile> files) {
+    @PostMapping("/{moimId}/image") // U of CRUD : 다이어리 편집을 위한 이미지 업로드
+    public ResponseEntity<TicketImageResponseDTO> uploadDiaryImage(@AuthenticationPrincipal CustomOAuth2Member customOAuth2Member, @PathVariable Long moimId, @RequestPart List<MultipartFile> files) {
 
-        return null;
+        String username = usernameConverter(customOAuth2Member.getUsername());
+        TicketImageResponseDTO ticketImageResponseDTO = diaryService.uploadImages(moimId, files);
+
+        return switch (ticketImageResponseDTO.getResultCode()) {
+            case "201 Created" -> ResponseEntity.status(HttpStatus.CREATED).body(ticketImageResponseDTO);
+            case "206 Partial Content" -> ResponseEntity.status(HttpStatus.PARTIAL_CONTENT).body(ticketImageResponseDTO);
+            case "502 Bad Gateway" -> ResponseEntity.status(HttpStatus.BAD_GATEWAY).body(ticketImageResponseDTO);
+            default -> ResponseEntity.badRequest().body(ticketImageResponseDTO); // 400 Bad Request
+        };
     }
 
-    @DeleteMapping("/{moimId}/diary") // D of CRUD : 다이어리 삭제
+    @DeleteMapping("/{moimId}") // D of CRUD : 다이어리 삭제
     public ResponseEntity<String> deleteDiary(@AuthenticationPrincipal CustomOAuth2Member customOAuth2Member, @PathVariable Long moimId) {
         return null;
+    }
+
+    private String usernameConverter(String originString) {
+        return originString.replace(" ", "-");
     }
 }

--- a/back-end/src/main/java/kr/co/ssalon/web/dto/DiaryFetchResponseDTO.java
+++ b/back-end/src/main/java/kr/co/ssalon/web/dto/DiaryFetchResponseDTO.java
@@ -1,0 +1,12 @@
+package kr.co.ssalon.web.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class DiaryFetchResponseDTO {
+
+    private String resultCode;
+    private String resultJSON;
+}

--- a/back-end/src/main/java/kr/co/ssalon/web/dto/DiaryInitResponseDTO.java
+++ b/back-end/src/main/java/kr/co/ssalon/web/dto/DiaryInitResponseDTO.java
@@ -1,0 +1,15 @@
+package kr.co.ssalon.web.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class DiaryInitResponseDTO {
+
+    private String resultCode;
+    private String resultJsonUpload;
+    private List<String> resultCopyFiles;
+}


### PR DESCRIPTION
# feat: 증표 뒷면(다이어리) 초기 생성 및 수정 기능 추가
## API 명세
### `GET /api/diary/{moidId}`
+ 모임ID에 해당하는 모임이 가진 증표의 디자인 JSON 파일을 호출합니다.
+ 필수적인 리퀘스트 파라미터 또는 바디 없습니다.
+ 부가적인 리퀘스트 파라미터 또는 바디 없습니다.
+ 요청한 모임 증표의 직렬화된 JSON 데이터를 반환합니다.

### `POST /api/diary/{moidId}`
+ 모임ID에 해당하는 모임의 초기 증표를 템플릿을 복제해 생성합니다.
+ 필수적인 리퀘스트 파라미터 또는 바디 없습니다.
+ 부가적인 리퀘스트 파라미터 또는 바디 없습니다.
+ 성공적으로 복제된 모임 증표의 직렬화된 JSON 데이터를 반환합니다.

### `PUT /api/diary/{moidId}`
+ 모임ID에 해당하는 모임의 증표 디자인을 수정, 갱신합니다.
+ 필수적인 리퀘스트 바디 : form-data 형태로 데이터를 전달해야 합니다.
  - json : JSON 스트링 데이터 / application-json
+ 부가적인 리퀘스트 파라미터 또는 바디 없습니다.
+ 성공적으로 수정된 모임 증표와 관련된 JSON 데이터를 반환합니다. (임시)

### `POST /api/diary/{moidId}/image`
+ 증표 편집 과정에서 발생한 이미지 삽입에 대응해 파일을 S3로 업로드 한 후 링크를 반환합니다.
+ 필수적인 리퀘스트 바디 : form-data 형태로 데이터를 전달해야 합니다. JWT 인증 필요.
  - files : 증표에 삽입된 0 또는 1개, 혹은 다수의 이미지 데이터
+ 부가적인 리퀘스트 파라미터 또는 바디 없습니다.
+ 성공적으로 업로드 된 이미지 링크의 String 리스트를 반환합니다.

## 부가 내용
+ 테스트용 EC2 서버로의 빠른 반영을 위해 성공 케이스에 대해서만 고려하여 작성한 코드입니다.
+ 코드 수정 및 Swagger 반영 등을 위해 Merge 시 브랜치를 삭제하지 말아주시기 바랍니다.