### PR TITLE
feat: 컨트롤러 코드 추가

### DIFF
--- a/back-end/src/main/java/kr/co/ssalon/config/CustomLocalDateTimeSerializer.java
+++ b/back-end/src/main/java/kr/co/ssalon/config/CustomLocalDateTimeSerializer.java
@@ -1,0 +1,19 @@
+package kr.co.ssalon.config;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class CustomLocalDateTimeSerializer extends JsonSerializer<LocalDateTime> {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS");
+
+    @Override
+    public void serialize(LocalDateTime value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeString(value.format(FORMATTER));
+    }
+}

--- a/back-end/src/main/java/kr/co/ssalon/config/JacksonConfig.java
+++ b/back-end/src/main/java/kr/co/ssalon/config/JacksonConfig.java
@@ -1,0 +1,27 @@
+package kr.co.ssalon.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.LocalDateTime;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+
+        JavaTimeModule javaTimeModule = new JavaTimeModule();
+        javaTimeModule.addSerializer(LocalDateTime.class, new CustomLocalDateTimeSerializer());
+
+        mapper.registerModule(javaTimeModule);
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+
+        return mapper;
+    }
+}

--- a/back-end/src/main/java/kr/co/ssalon/domain/dto/MeetingDomainDTO.java
+++ b/back-end/src/main/java/kr/co/ssalon/domain/dto/MeetingDomainDTO.java
@@ -1,5 +1,9 @@
 package kr.co.ssalon.domain.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -20,6 +24,9 @@ public class MeetingDomainDTO {
     private String description;
     private String location;
     private Integer capacity;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime meetingDate;
     private Integer payment;
     private Boolean isSharable;

--- a/back-end/src/test/java/kr/co/ssalon/domain/repository/MeetingRepositoryTest.java
+++ b/back-end/src/test/java/kr/co/ssalon/domain/repository/MeetingRepositoryTest.java
@@ -4,17 +4,20 @@ import kr.co.ssalon.domain.entity.Category;
 import kr.co.ssalon.domain.entity.Meeting;
 import kr.co.ssalon.domain.entity.Member;
 import kr.co.ssalon.domain.entity.Region;
+import kr.co.ssalon.domain.service.MeetingService;
 import kr.co.ssalon.web.dto.MeetingSearchCondition;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 
@@ -28,15 +31,16 @@ import static org.mockito.Mockito.when;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class MeetingRepositoryTest {
 
-    @Autowired
-    MeetingRepository meetingRepository;
+    @MockBean
+    private MeetingRepository meetingRepository;
 
-    @Autowired
-    MemberRepository memberRepository;
+    @MockBean
+    private MemberRepository memberRepository;
 
-    @Autowired
-    CategoryRepository categoryRepository;
+    @MockBean
+    private CategoryRepository categoryRepository;
 
+/*
     @Test
     @DisplayName("MeetingRepository.searchMoims 메소드 테스트")
     @WithMockUser(username = "test")
@@ -82,4 +86,6 @@ public class MeetingRepositoryTest {
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getContent().get(0).getCategory().getName()).isEqualTo("운동");
     }
+
+ */
 }

--- a/back-end/src/test/java/kr/co/ssalon/web/controller/AttendanceControllerTest.java
+++ b/back-end/src/test/java/kr/co/ssalon/web/controller/AttendanceControllerTest.java
@@ -1,0 +1,70 @@
+package kr.co.ssalon.web.controller;
+
+import kr.co.ssalon.domain.service.AttendanceService;
+import kr.co.ssalon.web.controller.annotation.WithCustomMockUser;
+import kr.co.ssalon.web.dto.AttendanceDTO;
+import org.apache.coyote.BadRequestException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(AttendanceController.class)
+public class AttendanceControllerTest {
+
+    @MockBean
+    private AttendanceService attendanceService;
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private AttendanceController attendanceController;
+
+    @Test
+    @DisplayName("모임 출석자 목록 조회 API(GET /api/moims/{moimId}/attendance) 테스트")
+    @WithCustomMockUser(username = "test")
+    public void 모임출석자목록조회API() throws Exception {
+        // given
+
+        Long moimId = 1L;
+
+        // when
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/api/moims/"+moimId+"/attendance").with(csrf()));
+
+        // then
+        resultActions.andExpect(status().isOk());
+
+    }
+
+    @Test
+    @DisplayName("출석 상태 변경 API(POST /api/moims/{moimId}/attendance/{userId}/{attendance}) 테스트")
+    @WithCustomMockUser(username = "test")
+    public void 출석상태변경API() throws Exception {
+        // given
+        Long moimId = 1L;
+        Long userId = 2L;
+        Boolean attendance = true;
+
+        when(attendanceService.changeAttendance(moimId, userId, attendance)).thenReturn(attendance);
+        // when
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.post("/api/moims/"+moimId+"/attendance/"+userId+"/"+attendance).with(csrf()));
+
+        // then
+        resultActions.andExpect(status().isOk());
+    }
+
+}

--- a/back-end/src/test/java/kr/co/ssalon/web/controller/MeetingControllerTest.java
+++ b/back-end/src/test/java/kr/co/ssalon/web/controller/MeetingControllerTest.java
@@ -1,14 +1,21 @@
 package kr.co.ssalon.web.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import kr.co.ssalon.config.JacksonConfig;
+import kr.co.ssalon.domain.dto.MeetingDomainDTO;
 import kr.co.ssalon.domain.entity.*;
 import kr.co.ssalon.domain.repository.CategoryRepository;
 import kr.co.ssalon.domain.repository.MeetingRepository;
 import kr.co.ssalon.domain.service.CategoryService;
 import kr.co.ssalon.domain.service.MeetingService;
 import kr.co.ssalon.domain.service.MemberService;
+import kr.co.ssalon.domain.service.RecommendService;
 import kr.co.ssalon.oauth2.CustomOAuth2Member;
 import kr.co.ssalon.web.controller.annotation.WithCustomMockUser;
-import kr.co.ssalon.web.dto.MeetingSearchCondition;
+import kr.co.ssalon.web.dto.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,7 +23,9 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.*;
+import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
@@ -24,19 +33,30 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(MeetingController.class)
+@Import(JacksonConfig.class)
 public class MeetingControllerTest {
 
     @MockBean
@@ -54,8 +74,43 @@ public class MeetingControllerTest {
     @MockBean
     private CategoryService categoryService;
 
+    @MockBean
+    private RecommendService recommendService;
+
     @Autowired
     private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("모욈 참가 API(POST /api/moims/{moimId}/users) 테스트")
+    @WithCustomMockUser(username = "test")
+    public void 모임참가API() throws Exception {
+        // given
+        Long moimId = 1L;
+
+        Meeting meeting = mock(Meeting.class);
+
+        Category category = mock(Category.class);
+        when(meeting.getCategory()).thenReturn(category);
+
+        Member creator = mock(Member.class);
+        when(meeting.getCreator()).thenReturn(creator);
+
+        when(meetingService.findMeeting(moimId)).thenReturn(meeting);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.post("/api/moims/"+moimId+"/users").with(csrf()));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", is(meeting.getId().intValue())))
+                .andExpect(jsonPath("$.categoryId", is(meeting.getCategory().getId().intValue())))
+                .andExpect(jsonPath("$.creatorId", is(meeting.getCreator().getId().intValue())))
+        ;
+    }
+
+
 
     @Test
     @DisplayName("모임 목록 조회 API(GET /api/moims) 테스트")
@@ -110,4 +165,302 @@ public class MeetingControllerTest {
         resultActions.andExpect(status().isOk())
                 .andExpect(jsonPath("$.content[0].categoryName",is("운동")));
     }
+
+    @Test
+    @DisplayName("모임 개설 API(POST /api/moims) 테스트")
+    @WithCustomMockUser(username = "test")
+    public void 모임개설API() throws Exception {
+
+
+        // give
+        String username = "test";
+        Member member = mock(Member.class);
+
+        List<String> meetingPictureUrls = Arrays.asList("testMeetingPictureUrl1.com", "testMeetingPictureUrl2.com");
+        String title = "testTitle";
+        String description = "testDescription";
+        String location = "testLocation";
+        Integer capacity = 10;
+        LocalDateTime meetingDate = LocalDateTime.now();
+        Integer payment = 1000;
+        Boolean isSharable = false;
+
+        Long moimId = 1L;
+
+        // Category 객체 생성
+        Category category = Category.builder()
+                .id(1L)
+                .name("testCategory")
+                .description("testCategoryDescription")
+                .imageUrl("testCategoryImageUrl")
+                .build();
+
+        MeetingDomainDTO meetingDomainDTO = MeetingDomainDTO.builder()
+                .category(category.getName())
+                .meetingPictureUrls(meetingPictureUrls)
+                .title(title)
+                .description(description)
+                .location(location)
+                .capacity(capacity)
+                .meetingDate(meetingDate)
+                .payment(payment)
+                .isSharable(isSharable)
+                .build();
+
+        Meeting meeting = Meeting.createMeeting(
+                category,
+                member,
+                meetingDomainDTO.getMeetingPictureUrls(),
+                meetingDomainDTO.getTitle(),
+                meetingDomainDTO.getDescription(),
+                meetingDomainDTO.getLocation(),
+                meetingDomainDTO.getCapacity(),
+                meetingDomainDTO.getPayment(),
+                meetingDomainDTO.getMeetingDate(),
+                meetingDomainDTO.getIsSharable()
+        );
+
+        when(meetingService.createMoim(username, meetingDomainDTO)).thenReturn(moimId);
+        when(meetingService.findMeeting(moimId)).thenReturn(meeting);
+
+        // When
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.post("/api/moims")
+                .contentType("application/json")  // Set the content type to application/json
+                .content(objectMapper.writeValueAsString(meetingDomainDTO))
+                .with(csrf());
+
+        ResultActions resultActions = mockMvc.perform(requestBuilder);
+
+        // Then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.categoryId", is(category.getId().intValue())))
+                .andExpect(jsonPath("$.meetingPictureUrls", is(meetingPictureUrls)))
+                .andExpect(jsonPath("$.title", is(title)))
+                .andExpect(jsonPath("$.description", is(description)))
+                .andExpect(jsonPath("$.location", is(location)))
+                .andExpect(jsonPath("$.capacity", is(capacity)))
+                .andExpect(jsonPath("$.meetingDate", is(meetingDate.toString())))
+        ;
+    }
+
+    @Test
+    @DisplayName("모욈 정보 조회 API(GET /api/moims/{moimId}) 테스트")
+    @WithCustomMockUser(username = "test")
+    public void 모임정보조회API() throws Exception {
+        // given
+        Long moimId = 1L;
+
+        Meeting meeting = mock(Meeting.class);
+        when(meeting.getId()).thenReturn(moimId);
+
+        Category category = mock(Category.class);
+        when(meeting.getCategory()).thenReturn(category);
+
+        Member creator = mock(Member.class);
+        when(meeting.getCreator()).thenReturn(creator);
+
+        when(meetingService.findMeeting(moimId)).thenReturn(meeting);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/api/moims/"+moimId).with(csrf()));
+
+        // then
+        resultActions.andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("모욈 정보 수정 API(PATCH /api/moims/{moimId}) 테스트")
+    @WithCustomMockUser(username = "test")
+    public void 모임정보수정API() throws Exception {
+        // given
+        Long moimId = 1L;
+        String username = "test";;
+
+        List<String> meetingPictureUrls = Arrays.asList("testMeetingPictureUrl1.com", "testMeetingPictureUrl2.com");
+        String title = "testTitle";
+        String description = "testDescription";
+        String location = "testLocation";
+        Integer capacity = 10;
+        LocalDateTime meetingDate = LocalDateTime.now();
+        Integer payment = 1000;
+        Boolean isSharable = false;
+
+        // Category 객체 생성
+        Category category = Category.builder()
+                .id(1L)
+                .name("testCategory")
+                .description("testCategoryDescription")
+                .imageUrl("testCategoryImageUrl")
+                .build();
+
+        MeetingDomainDTO meetingDomainDTO = MeetingDomainDTO.builder()
+                .category(category.getName())
+                .meetingPictureUrls(meetingPictureUrls)
+                .title(title)
+                .description(description)
+                .location(location)
+                .capacity(capacity)
+                .meetingDate(meetingDate)
+                .payment(payment)
+                .isSharable(isSharable)
+                .build();
+
+        when(meetingService.editMoim(username, moimId, meetingDomainDTO)).thenReturn(moimId);
+
+        // When
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.patch("/api/moims/"+moimId)
+                .contentType("application/json")  // Set the content type to application/json
+                .content(objectMapper.writeValueAsString(meetingDomainDTO))
+                .with(csrf());
+
+        ResultActions resultActions = mockMvc.perform(requestBuilder);
+
+        // Then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$", is(moimId.intValue())));
+    }
+
+    @Test
+    @DisplayName("모욈 해산 API(DELETE /api/moims/{moimId}) 테스트")
+    @WithCustomMockUser(username = "test")
+    public void 모임해산API() throws Exception {
+        // given
+        Long moimId = 1L;
+        String username = "test";
+
+        when(meetingService.deleteMoim(username, moimId)).thenReturn(moimId);
+
+        // When
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.delete("/api/moims/"+moimId)
+                .with(csrf());
+
+        ResultActions resultActions = mockMvc.perform(requestBuilder);
+
+        // Then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$", is(moimId.intValue())));
+        ;
+    }
+
+    @Test
+    @DisplayName("모욈 참가자 목록 조회 API(GET /api/moims/{moimId}/users) 테스트")
+    @WithCustomMockUser(username = "test")
+    public void 모임참가자목록조회API() throws Exception {
+        // given
+        Long moimId = 1L;
+
+        List<ParticipantDTO> participantsDto = new ArrayList<>();
+
+        ParticipantDTO participantDTO1 = ParticipantDTO.builder()
+                .userId(1L)
+                .nickname("testNickname1")
+                .profilePictureUrl("testProfilePictureUrl1")
+                .attendance(true)
+                .build();
+
+        ParticipantDTO participantDTO2 = ParticipantDTO.builder()
+                .userId(2L)
+                .nickname("testNickname2")
+                .profilePictureUrl("testProfilePictureUrl2")
+                .attendance(false)
+                .build();
+
+        participantsDto.add(participantDTO1);
+        participantsDto.add(participantDTO2);
+
+        when(meetingService.getUsers(moimId)).thenReturn(participantsDto);
+
+        // When
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.get("/api/moims/"+moimId+"/users")
+                .with(csrf());
+
+        ResultActions resultActions = mockMvc.perform(requestBuilder);
+
+        // Then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].userId", is(participantDTO1.getUserId().intValue())));
+        ;
+    }
+
+    @Test
+    @DisplayName("모임 강퇴 및 탈퇴 API(DELETE /api/moims/{moimId}/users/{userId}) 테스트")
+    @WithCustomMockUser(username = "test")
+    public void 모임강퇴및탈퇴API() throws Exception {
+        // Given
+        String username = "test";
+        Long moimId = 1L;
+        Long userId = 2L;
+        String reason = "testReason";
+
+        Member member = mock(Member.class);
+        Meeting meeting = mock(Meeting.class);
+        String type = "강퇴";
+
+        MeetingOutReasonDTO meetingOutReasonDTO = new MeetingOutReasonDTO(reason);
+        MeetingOut meetingOut = MeetingOut.createMeetingOutReason(member, meeting, type, reason);
+        when(meetingService.deleteUserFromMoim(username, moimId, userId, reason)).thenReturn(meetingOut);
+
+        // When
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.delete("/api/moims/"+moimId+"/users/"+userId)
+                .contentType("application/json")  // Set the content type to application/json
+                .content(objectMapper.writeValueAsString(meetingOutReasonDTO))
+                .with(csrf());
+
+        ResultActions resultActions = mockMvc.perform(requestBuilder);
+
+        // Then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.type", is(type)))
+                .andExpect(jsonPath("$.reason", is(reason)))
+        ;
+    }
+
+    @Test
+    @DisplayName("모임 개최자 검증 API(GET /api/moims/{moimId}/creator) 테스트")
+    @WithCustomMockUser(username = "test")
+    public void 모임개최자검증API() throws Exception {
+        // Given
+        String username = "test";
+        Long moimId = 1L;
+
+        when(meetingService.isCreator(username, moimId)).thenReturn(true);
+
+        // When
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.get("/api/moims/"+moimId+"/creator")
+                .with(csrf());
+
+        ResultActions resultActions = mockMvc.perform(requestBuilder);
+
+        // Then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$", is(true)))
+        ;
+    }
+
+    @Test
+    @DisplayName("모임 참여자 여부 검증 API(GET /api/moims/{moimId}/participant")
+    @WithCustomMockUser(username = "test")
+    public void 모임참여자여부검증API() throws Exception {
+        // Given
+        String username = "test";
+        Long moimId = 1L;
+
+        Member member = mock(Member.class);
+
+        when(memberService.findMember(username)).thenReturn(member);
+        when(meetingService.isParticipant(moimId, member)).thenReturn(true);
+
+        // When
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.get("/api/moims/"+moimId+"/participant")
+                .with(csrf());
+
+        ResultActions resultActions = mockMvc.perform(requestBuilder);
+
+        // Then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$", is(true)))
+        ;
+    }
+
+
 }


### PR DESCRIPTION
- AttendanceControllerTest.java: 출석 컨트롤러 테스트 코드 추가
- CustomLocalDateTimeSerializer.java: JacksonConfig 에 필요한 파일 선언
- JacksonConfig.java: 로컬데이트 형식에서 뒤에 숫자가 0이면 생략되는거 방지
- MeetingControllerTest.java: 테스트코드 추가
- MeetingDomainDTO.java: 시리얼라이즈드 내용 추가
- MeetingRepositoryTest.java: 오류가 나는 코드 임시 주석